### PR TITLE
Refactor location metadata, get rid of `Range<Idx>`

### DIFF
--- a/crates/cyan_compiler/src/ir/ast/mod.rs
+++ b/crates/cyan_compiler/src/ir/ast/mod.rs
@@ -2,8 +2,8 @@
 
 use internment::Intern;
 
-/// A helper macro that adds a `span` field to an AST node and implements [Spanned] for it.
-macro_rules! spanned {
+/// A helper macro that adds a `location` field to an AST node and implements [Located] for it.
+macro_rules! located {
   // Handle structs.
   (
     $(#[$outer:meta])*
@@ -20,13 +20,13 @@ macro_rules! spanned {
         $(#[$inner])*
         $field_vis $field : $ty,
       )*
-      /// Contains the node's span.
-      pub span: crate::span::Span,
+      /// Contains the node's location.
+      pub location: crate::location::Location,
     }
 
-    impl crate::span::Spanned for $name {
-      fn span(&self) -> &crate::span::Span {
-        &self.span
+    impl crate::location::Located for $name {
+      fn location(&self) -> &crate::location::Location {
+        &self.location
       }
     }
   };
@@ -49,24 +49,24 @@ macro_rules! spanned {
       ),*
     }
 
-    impl crate::span::Spanned for $name {
-      fn span(&self) -> &crate::span::Span {
+    impl crate::location::Located for $name {
+      fn location(&self) -> &crate::location::Location {
         match self {
-          $($name::$variant(expr) => expr.span(),)*
+          $($name::$variant(expr) => expr.location(),)*
         }
       }
     }
   };
 }
 
-spanned! {
+located! {
   #[derive(Debug, PartialEq, Eq)]
   pub struct Program {
     pub function: Function,
   }
 }
 
-spanned! {
+located! {
   #[derive(Debug, PartialEq, Eq)]
   pub struct Function {
     pub name: Ident,
@@ -74,14 +74,14 @@ spanned! {
   }
 }
 
-spanned! {
+located! {
   #[derive(Debug, PartialEq, Eq)]
   pub enum Statement {
     Return(Expression),
   }
 }
 
-spanned! {
+located! {
   #[derive(Clone, Debug, PartialEq, Eq)]
   pub enum Expression {
     Constant(Int),
@@ -90,7 +90,7 @@ spanned! {
   }
 }
 
-spanned! {
+located! {
   #[derive(Clone, Debug, PartialEq, Eq)]
   pub struct Unary {
     pub op: UnaryOp,
@@ -108,7 +108,7 @@ pub enum UnaryOp {
   Not,
 }
 
-spanned! {
+located! {
   #[derive(Clone, Debug, PartialEq, Eq)]
   pub struct Binary {
     pub op: BinaryOp,
@@ -152,14 +152,14 @@ pub enum BinaryOp {
   Or,
 }
 
-spanned! {
+located! {
   #[derive(Clone, Debug, PartialEq, Eq)]
   pub struct Int {
     pub value: isize,
   }
 }
 
-spanned! {
+located! {
   #[derive(Clone, Debug, PartialEq, Eq)]
   pub struct Ident {
     pub value: Intern<String>,

--- a/crates/cyan_compiler/src/ir/tac/mod.rs
+++ b/crates/cyan_compiler/src/ir/tac/mod.rs
@@ -7,8 +7,6 @@ use std::fmt;
 use internment::Intern;
 pub use passes::*;
 
-use crate::span::Span;
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct Program {
   pub function: Function,

--- a/crates/cyan_compiler/src/ir/tac/passes.rs
+++ b/crates/cyan_compiler/src/ir/tac/passes.rs
@@ -2,21 +2,22 @@ use thiserror::Error;
 
 use crate::ir::ast;
 use crate::ir::tac::*;
+use crate::location::Location;
 
 #[derive(Debug, Error)]
-#[error("AST lowering error [{span}]: {message}")]
+#[error("AST lowering error {location}: {message}")]
 pub struct LoweringError {
   /// The error message.
   pub message: String,
-  /// The span of the error.
-  pub span: Span,
+  /// The location of the error.
+  pub location: Location,
 }
 
 impl LoweringError {
-  pub fn new(message: impl AsRef<str> + Into<String>, span: Span) -> Self {
+  pub fn new(message: impl AsRef<str> + Into<String>, location: Location) -> Self {
     Self {
       message: message.into(),
-      span,
+      location,
     }
   }
 }
@@ -320,7 +321,7 @@ impl LoweringPass {
       | ast::BinaryOp::And | ast::BinaryOp::Or => {
         Err(LoweringError::new(
           "|| and && cannot be directly lowered to TAC",
-          binary.span.clone(),
+          binary.location.clone(),
         ))
       },
     }

--- a/crates/cyan_compiler/src/ir/tac/passes.rs
+++ b/crates/cyan_compiler/src/ir/tac/passes.rs
@@ -321,7 +321,7 @@ impl LoweringPass {
       | ast::BinaryOp::And | ast::BinaryOp::Or => {
         Err(LoweringError::new(
           "|| and && cannot be directly lowered to TAC",
-          binary.location.clone(),
+          binary.location,
         ))
       },
     }

--- a/crates/cyan_compiler/src/lexer/token.rs
+++ b/crates/cyan_compiler/src/lexer/token.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::span::Span;
+use crate::location::Location;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TokenKind {
@@ -107,23 +107,27 @@ impl TokenKind {
 pub struct Token {
   pub kind: TokenKind,
   pub value: String,
-  pub span: Span,
+  pub location: Location,
 }
 
 impl Token {
-  pub fn new(kind: TokenKind, value: String, span: Span) -> Self {
-    Self { kind, value, span }
+  pub fn new(kind: TokenKind, value: String, location: Location) -> Self {
+    Self {
+      kind,
+      value,
+      location,
+    }
   }
 
   /// Returns a token signalling unexpected input. The token contains the invalid character(s).
-  pub fn invalid(value: String, span: Span) -> Self {
-    Self::new(TokenKind::Invalid, value, span)
+  pub fn invalid(value: String, location: Location) -> Self {
+    Self::new(TokenKind::Invalid, value, location)
   }
 
   /// Returns a token that signals the end of the input stream. Using it so we don't need to
   /// wrap/unwrap every token in [Option].
-  pub fn eof(span: Span) -> Self {
-    Self::new(TokenKind::Eof, String::new(), span)
+  pub fn eof(location: Location) -> Self {
+    Self::new(TokenKind::Eof, String::new(), location)
   }
 
   /// Returns `true` if the token is the end of input token.
@@ -170,7 +174,7 @@ impl Token {
 
 impl Default for Token {
   fn default() -> Self {
-    Self::eof(Span::default())
+    Self::eof(Location::default())
   }
 }
 

--- a/crates/cyan_compiler/src/lib.rs
+++ b/crates/cyan_compiler/src/lib.rs
@@ -7,5 +7,6 @@
 pub mod emitter;
 pub mod ir;
 pub mod lexer;
+pub mod location;
 pub mod parser;
 pub mod span;

--- a/crates/cyan_compiler/src/location.rs
+++ b/crates/cyan_compiler/src/location.rs
@@ -10,7 +10,7 @@ pub trait Located {
 }
 
 /// The location of a single node.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Location {
   /// Absolute byte offsets in the input.
   pub offsets: Span<usize>,

--- a/crates/cyan_compiler/src/location.rs
+++ b/crates/cyan_compiler/src/location.rs
@@ -1,0 +1,93 @@
+use std::cmp::{Ord, Ordering, PartialOrd};
+use std::fmt;
+
+use crate::span::Span;
+
+/// A trait for nodes that should have a location.
+pub trait Located {
+  /// Returns the location of the node.
+  fn location(&self) -> &Location;
+}
+
+/// The location of a single node.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Location {
+  /// Absolute byte offsets in the input.
+  pub offsets: Span<usize>,
+  /// The first and last line of the node.
+  pub lines: Span<usize>,
+  /// The first and last column of the node.
+  pub cols: Span<usize>,
+}
+
+impl Location {
+  pub fn new(offsets: Span<usize>, lines: Span<usize>, cols: Span<usize>) -> Self {
+    Self {
+      offsets,
+      lines,
+      cols,
+    }
+  }
+
+  /// Merges two locations into one simply by combining their spans' start and end.
+  pub fn merge(start: &Self, end: &Self) -> Self {
+    Self {
+      offsets: Span::new(start.offsets.start, end.offsets.end),
+      lines: Span::new(start.lines.start, end.lines.end),
+      cols: Span::new(start.cols.start, end.cols.end),
+    }
+  }
+
+  /// Returns starting line and column of the location.
+  pub fn start(&self) -> (usize, usize) {
+    (self.lines.start, self.cols.start)
+  }
+}
+
+impl Default for Location {
+  fn default() -> Self {
+    Self {
+      offsets: Span::new(0, 0),
+      lines: Span::new(1, 1),
+      cols: Span::new(1, 1),
+    }
+  }
+}
+
+impl fmt::Debug for Location {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+      f,
+      "({}:{} - {}:{} @ {:?})",
+      self.lines.start, self.cols.start, self.lines.end, self.cols.end, self.offsets
+    )
+  }
+}
+
+impl fmt::Display for Location {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+      f,
+      "({}:{} - {}:{})",
+      self.lines.start, self.cols.start, self.lines.end, self.cols.end
+    )
+  }
+}
+
+impl Ord for Location {
+  fn cmp(&self, other: &Self) -> Ordering {
+    let ord = self.lines.start.cmp(&other.lines.start);
+
+    if ord == Ordering::Equal {
+      self.cols.start.cmp(&other.cols.start)
+    } else {
+      ord
+    }
+  }
+}
+
+impl PartialOrd for Location {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}

--- a/crates/cyan_compiler/src/parser/parser.rs
+++ b/crates/cyan_compiler/src/parser/parser.rs
@@ -95,19 +95,17 @@ impl Parser {
 
   /// Checks if the next token is valid, i.e. not [TokenKind::Invalid] and not [TokenKind::Eof].
   fn check_token(&self, token: &Token) -> Result<()> {
-    let location = token.location.clone();
-
     match token.kind {
       | TokenKind::Invalid => {
         Err(ParseError::new(
           format!("a '{}' is not allowed", token.value),
-          location,
+          token.location,
         ))
       },
       | TokenKind::Eof => {
         Err(ParseError::new(
           "the end of the input is reached, but more is expected",
-          location,
+          token.location,
         ))
       },
       | _ => Ok(()),
@@ -125,7 +123,7 @@ impl Parser {
           kind.description(),
           token.value
         ),
-        token.location.clone(),
+        token.location,
       ));
     }
 
@@ -165,7 +163,7 @@ impl Parser {
       | _ => {
         Err(ParseError::new(
           format!("expected statement, found '{}'", token.value),
-          token.location.clone(),
+          token.location,
         ))
       },
     }
@@ -193,8 +191,8 @@ impl Parser {
           let op = self.binary()?;
           let right = self.expression(precedence + 1)?;
 
-          let left_location = left.location().clone();
-          let right_location = right.location().clone();
+          let left_location = *left.location();
+          let right_location = *right.location();
 
           left = ast::Expression::Binary(ast::Binary {
             op,
@@ -223,7 +221,7 @@ impl Parser {
       | _ => {
         Err(ParseError::new(
           format!("expected expression, found '{}'", token.value),
-          token.location.clone(),
+          token.location,
         ))
       },
     }
@@ -247,13 +245,13 @@ impl Parser {
     let value = token.value.parse().map_err(|_| {
       ParseError::new(
         format!("expected a constant, found '{}'", token.value),
-        token.location.clone(),
+        token.location,
       )
     })?;
 
     Ok(ast::Expression::Constant(ast::Int {
       value,
-      location: token.location.clone(),
+      location: token.location,
     }))
   }
 
@@ -268,7 +266,7 @@ impl Parser {
       | _ => {
         return Err(ParseError::new(
           format!("expected unary operator, found '{}'", token.value),
-          token.location.clone(),
+          token.location,
         ))
       },
     };
@@ -313,7 +311,7 @@ impl Parser {
       | _ => {
         return Err(ParseError::new(
           format!("expected binary operator, found '{}'", token.value),
-          token.location.clone(),
+          token.location,
         ))
       },
     };
@@ -328,7 +326,7 @@ impl Parser {
     if token.kind != TokenKind::Ident {
       return Err(ParseError::new(
         format!("expected identifier, found '{}'", token.value),
-        token.location.clone(),
+        token.location,
       ));
     }
 

--- a/crates/cyan_compiler/src/span.rs
+++ b/crates/cyan_compiler/src/span.rs
@@ -1,92 +1,109 @@
-use std::cmp::{Ord, Ordering, PartialOrd};
-use std::fmt;
-use std::ops::Range;
+use core::fmt;
+use core::ops::{Bound, RangeBounds};
 
-/// A trait for expressions that have a location span.
-pub trait Spanned {
-  /// Returns the location span of the expression.
-  fn span(&self) -> &Span;
+/// A half-open span, bounded inclusively below and exclusively above.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Span<Idx> {
+  pub start: Idx,
+  pub end: Idx,
 }
 
-/// The location span of a single expression.
-#[derive(Clone, PartialEq, Eq)]
-pub struct Span {
-  /// Absolute byte offsets in the input.
-  pub offsets: Range<usize>,
-  /// The first and last line of the expression.
-  pub lines: Range<usize>,
-  /// The first and last column of the expression.
-  pub cols: Range<usize>,
-}
-
-impl Span {
-  pub fn new(offsets: Range<usize>, lines: Range<usize>, cols: Range<usize>) -> Self {
-    Self {
-      offsets,
-      lines,
-      cols,
-    }
+impl<Idx> Span<Idx> {
+  pub fn new(start: Idx, end: Idx) -> Self {
+    Self { start, end }
   }
 
-  /// Merges two spans into one simply by combining their ranges' start and end.
-  pub fn merge(start: &Self, end: &Self) -> Self {
-    Self {
-      offsets: start.offsets.start..end.offsets.end,
-      lines: start.lines.start..end.lines.end,
-      cols: start.cols.start..end.cols.end,
-    }
+  /// Converts [Range][core::ops::Range] into a [Span].
+  pub fn from_range(range: core::ops::Range<Idx>) -> Self {
+    range.into()
   }
 
-  /// Returns starting line and column of the location span.
-  pub fn start(&self) -> (usize, usize) {
-    (self.lines.start, self.cols.start)
+  /// Converts [Span] into a [Range][core::ops::Range].
+  pub fn into_range(self) -> core::ops::Range<Idx> {
+    self.into()
   }
-}
 
-impl Default for Span {
-  fn default() -> Self {
-    Self {
-      offsets: 0..0,
-      lines: 1..1,
-      cols: 1..1,
-    }
+  /// Returns `true` if `item` is contained in the span.
+  ///
+  /// See [Range::contains][core::ops::Range::contains].
+  pub fn contains<U>(&self, item: &U) -> bool
+  where
+    Idx: PartialOrd<U>,
+    U: ?Sized + PartialOrd<Idx>,
+  {
+    <Self as RangeBounds<Idx>>::contains(self, item)
   }
-}
 
-impl fmt::Debug for Span {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(
-      f,
-      "({}:{} - {}:{} @ {:?})",
-      self.lines.start, self.cols.start, self.lines.end, self.cols.end, self.offsets
-    )
+  /// Returns `true` if the span contains no items.
+  ///
+  /// See [Range::contains][core::ops::Range::contains].
+  pub fn is_empty(&self) -> bool
+  where
+    Idx: PartialOrd,
+  {
+    self.start >= self.end
+  }
+
+  /// Returns the exact length of the span.
+  pub fn len(&self) -> usize
+  where
+    core::ops::Range<Idx>: ExactSizeIterator,
+    Self: Copy,
+  {
+    self.into_range().len()
   }
 }
 
-impl fmt::Display for Span {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(
-      f,
-      "({}:{} - {}:{})",
-      self.lines.start, self.cols.start, self.lines.end, self.cols.end
-    )
+impl<Idx: fmt::Debug> fmt::Debug for Span<Idx> {
+  fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.start.fmt(fmt)?;
+    write!(fmt, "..")?;
+    self.end.fmt(fmt)?;
+
+    Ok(())
   }
 }
 
-impl Ord for Span {
-  fn cmp(&self, other: &Self) -> Ordering {
-    let ord = self.lines.start.cmp(&other.lines.start);
-
-    if ord == Ordering::Equal {
-      self.cols.start.cmp(&other.cols.start)
-    } else {
-      ord
-    }
+impl<Idx> From<core::ops::Range<Idx>> for Span<Idx> {
+  fn from(core::ops::Range { start, end }: core::ops::Range<Idx>) -> Self {
+    Self { start, end }
   }
 }
 
-impl PartialOrd for Span {
-  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-    Some(self.cmp(other))
+impl<Idx> From<Span<Idx>> for core::ops::Range<Idx> {
+  fn from(value: Span<Idx>) -> Self {
+    value.start..value.end
+  }
+}
+
+impl<Idx> RangeBounds<Idx> for Span<Idx> {
+  fn start_bound(&self) -> Bound<&Idx> {
+    Bound::Included(&self.start)
+  }
+
+  fn end_bound(&self) -> Bound<&Idx> {
+    Bound::Excluded(&self.end)
+  }
+}
+
+impl<Idx> RangeBounds<Idx> for Span<&Idx> {
+  fn start_bound(&self) -> Bound<&Idx> {
+    Bound::Included(self.start)
+  }
+
+  fn end_bound(&self) -> Bound<&Idx> {
+    Bound::Excluded(self.end)
+  }
+}
+
+impl<Idx> IntoIterator for Span<Idx>
+where
+  core::ops::Range<Idx>: Iterator<Item = Idx>,
+{
+  type IntoIter = core::ops::Range<Idx>;
+  type Item = Idx;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.start..self.end
   }
 }


### PR DESCRIPTION
## Description

This PR does the following:

- Renames `Span` struct to `Location` to better reflect its purpose.
- Replaces built-in `Range<Idx>` with custom `Span<Idx>` which is `Copy` if `Idx` is `Copy`. This is definitely a bit more verbose solution, but it allowed to make `Location` also `Copy` and get rid of 37 clones here and there. :)
- Other minor adjustments.