### PR TITLE
Implement local variables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,8 @@
   "rust-analyzer.lens.implementations.enable": false,
   "[c]": {
     "editor.formatOnSave": false
+  },
+  "[markdown]": {
+    "editor.wordWrapColumn": 100
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ Compiler for a subset of C.
 ## Grammar
 
 ```ebnf
-<program>    ::= <function>
-<function>   ::= "int" <identifier> "(" "void" ")" "{" <statement> "}"
-<statement>  ::= "return" <expression> ";"
-<expression> ::= <factor> | <expression> <binary-op> <expression>
-<factor>     ::= <int> | <unary-op> <factor> | "(" <expression> ")"
-<unary-op>   ::= "-" | "~"
+<program>     ::= <function>
+<function>    ::= "int" <identifier> "(" "void" ")" "{" { <block-item> } "}"
+<block-item>  ::= <declaration> | <statement>
+<declaration> ::= "int" <identifier> [ "=" <expression> ] ";"
+<statement>   ::= "return" <expression> ";" | <expression> ";" | ";"
+<expression>  ::= <factor> | <expression> <binary-op> <expression>
+<factor>      ::= <int> | <identifier> | <unary-op> <factor> | "(" <expression> ")"
+<unary-op>    ::= "-" | "~" | "!"
+<binary-op>   ::= "+" | "-" | "*" | "/" | "%"
+                | "<<" | ">>" | "&" | "|" | "^"
+                | "&&" | "||" | "==" | "!=" | "<" | "<=" | ">" | ">="
 
-<binary-op>  ::= "+" | "-" | "*" | "/" | "%"
-               | "<<" | ">>" | "&" | "|" | "^"
-               | "&&" | "||" | "==" | "!=" | "<" | "<=" | ">" | ">="
-
-<identifier> ::= ? An identifier token ?
-<int>        ::= ? A constant token ?
+<identifier>  ::= ? An identifier token ?
+<int>         ::= ? A constant token ?
 ```
 
 ## Trees and IRs
@@ -38,15 +39,26 @@ This is a syntax tree representation of a C program.
 program = Program(function function)
 
 function =
-  | Function(identifier name, statement body)
+  | Function(identifier name, block_item* body)
+
+block_item =
+  | Declaration(declaration)
+  | Statement(statement)
+
+declaration =
+  | Declaration(identifier name, expression? initializer)
 
 statement =
   | Return(expression)
+  | Expression(expression)
+  | Null
 
 expression =
   | Constant(int)
+  | Var(identifier)
   | Unary(unary_op op, expression expression)
   | Binary(binary_op op, expression left, expression right)
+  | Assignment(expression lvalue, expression rvalue)
 
 unary_op =
   | BitNot

--- a/crates/cyan/tests/fixtures/invalid_parse/compound_invalid_operator.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/compound_invalid_operator.c
@@ -1,0 +1,8 @@
+// This is primarily a test for the compound assignment extra credit feature,
+// but the compiler should throw a parse error for this program whether it
+// supports that feature or not.
+int main(void) {
+  int a = 0;
+  a + = 1;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/declare_keyword_as_var.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/declare_keyword_as_var.c
@@ -1,0 +1,4 @@
+int main(void) {
+  int return = 4;
+  return return + 1;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/invalid_specifier.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/invalid_specifier.c
@@ -1,0 +1,4 @@
+int main(void) {
+  int foo bar = 3;
+  return bar;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/invalid_type.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/invalid_type.c
@@ -1,0 +1,4 @@
+int main(void) {
+  ints a = 1;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/invalid_variable_name.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/invalid_variable_name.c
@@ -1,0 +1,4 @@
+int main(void) {
+  int 10 = 0;
+  return 10;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/malformed_compound_assignment.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/malformed_compound_assignment.c
@@ -1,0 +1,9 @@
+// This is primarily a test for the compound assignment extra credit feature,
+// but the compiler should throw a parse error for this program whether it
+// supports that feature or not.
+
+int main(void) {
+    int a = 10;
+    a =/ 1;
+    return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/malformed_decrement.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/malformed_decrement.c
@@ -1,0 +1,8 @@
+// This is primarily a test for the increment/decrement extra credit feature,
+// but the compiler should throw a parse error for this program whether it
+// supports that feature or not.
+int main(void) {
+    int a = 0;
+    a - -;
+    return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/malformed_increment.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/malformed_increment.c
@@ -1,0 +1,8 @@
+// This is primarily a test for the increment/decrement extra credit feature,
+// but the compiler should throw a parse error for this program whether it
+// supports that feature or not.
+int main(void) {
+    int a = 0;
+    a + +;
+    return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/malformed_less_equal.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/malformed_less_equal.c
@@ -1,0 +1,7 @@
+int main(void)
+{
+    // make sure we lex < and = as two separate tokens
+    // this really tests the lexing logic from previous chapter,
+    // but the lexer didn't recognize = yet
+    return 1 < = 2;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/malformed_not_equal.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/malformed_not_equal.c
@@ -1,0 +1,7 @@
+int main(void)
+{
+    // make sure we lex ! and = as two separate tokens
+    // this really tests the lexing logic from previous chapter,
+    // but the lexer didn't recognize = yet
+    return 1 ! = 0;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/missing_semicolon.2.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/missing_semicolon.2.c
@@ -1,0 +1,5 @@
+int main(void) {
+    int a = 2
+    a = a + 4;
+    return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_parse/return_in_assignment.c
+++ b/crates/cyan/tests/fixtures/invalid_parse/return_in_assignment.c
@@ -1,0 +1,3 @@
+int main(void) {
+  int 10 = return 0;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/declared_after_use.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/declared_after_use.c
@@ -1,0 +1,5 @@
+int main(void) {
+  a = 1 + 2;
+  int a;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/invalid_lvalue.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/invalid_lvalue.c
@@ -1,0 +1,5 @@
+int main(void) {
+  int a = 2;
+  a + 3 = 4;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/invalid_lvalue_2.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/invalid_lvalue_2.c
@@ -1,0 +1,5 @@
+int main(void) {
+  int a = 2;
+  !a = 3;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/mixed_precedence_assignment.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/mixed_precedence_assignment.c
@@ -1,0 +1,5 @@
+int main(void) {
+  int a = 1;
+  int b = 2;
+  a = 3 * b = a;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/redefine.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/redefine.c
@@ -1,0 +1,5 @@
+int main(void) {
+  int a = 1;
+  int a = 2;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/undeclared_var.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/undeclared_var.c
@@ -1,0 +1,3 @@
+int main(void) {
+  return a;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/undeclared_var_and.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/undeclared_var_and.c
@@ -1,0 +1,3 @@
+int main(void) {
+  return 0 && a;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/undeclared_var_compare.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/undeclared_var_compare.c
@@ -1,0 +1,3 @@
+int main(void) {
+  return a < 5;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/undeclared_var_unary.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/undeclared_var_unary.c
@@ -1,0 +1,3 @@
+int main(void) {
+  return -a;
+}

--- a/crates/cyan/tests/fixtures/invalid_semantics/use_then_redefine.c
+++ b/crates/cyan/tests/fixtures/invalid_semantics/use_then_redefine.c
@@ -1,0 +1,6 @@
+int main(void) {
+  int a = 0;
+  return a;
+  int a = 1;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/valid/allocate_temps_and_vars.c
+++ b/crates/cyan/tests/fixtures/valid/allocate_temps_and_vars.c
@@ -1,0 +1,6 @@
+int main(void) {
+  int a = 2147483646;
+  int b = 0;
+  int c = a / 6 + !b;
+  return c * 2 == a - 1431655762;
+}

--- a/crates/cyan/tests/fixtures/valid/assignment.c
+++ b/crates/cyan/tests/fixtures/valid/assignment.c
@@ -1,0 +1,7 @@
+int main(void) {
+  int a = 42;
+  int b = a;
+  a = 69;
+  b = 420;
+  return a + b;
+}

--- a/crates/cyan/tests/fixtures/valid/assignment_in_initializer.c
+++ b/crates/cyan/tests/fixtures/valid/assignment_in_initializer.c
@@ -1,0 +1,5 @@
+int main(void) {
+  int a;
+  int b = a = 0;
+  return b;
+}

--- a/crates/cyan/tests/fixtures/valid/assignment_lowest_precedence.c
+++ b/crates/cyan/tests/fixtures/valid/assignment_lowest_precedence.c
@@ -1,0 +1,11 @@
+#ifdef SUPPRESS_WARNINGS
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wconstant-logical-operand"
+#endif
+#endif
+
+int main(void) {
+  int a;
+  a = 0 || 5;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/valid/assignment_mixed_precedence.c
+++ b/crates/cyan/tests/fixtures/valid/assignment_mixed_precedence.c
@@ -1,0 +1,6 @@
+int main(void) {
+  int a = 1;
+  int b = 0;
+  a = 3 * (b = a);
+  return a + b;
+}

--- a/crates/cyan/tests/fixtures/valid/assignment_val_in_initializer.c
+++ b/crates/cyan/tests/fixtures/valid/assignment_val_in_initializer.c
@@ -1,0 +1,4 @@
+int main(void) {
+  int a = a = 5;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/valid/local_var_missing_return.c
+++ b/crates/cyan/tests/fixtures/valid/local_var_missing_return.c
@@ -1,0 +1,4 @@
+int main(void) {
+  int a = 3;
+  a = a + 5;
+}

--- a/crates/cyan/tests/fixtures/valid/non_short_circuit_or.c
+++ b/crates/cyan/tests/fixtures/valid/non_short_circuit_or.c
@@ -1,0 +1,11 @@
+#ifdef SUPPRESS_WARNINGS
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wunused-value"
+#endif
+#endif
+
+int main(void) {
+  int a = 0;
+  0 || (a = 1);
+  return a;
+}

--- a/crates/cyan/tests/fixtures/valid/null_statement.c
+++ b/crates/cyan/tests/fixtures/valid/null_statement.c
@@ -1,0 +1,3 @@
+int main(void) {
+  ;
+}

--- a/crates/cyan/tests/fixtures/valid/null_then_return.c
+++ b/crates/cyan/tests/fixtures/valid/null_then_return.c
@@ -1,0 +1,4 @@
+int main(void) {
+  ;
+  return 0;
+}

--- a/crates/cyan/tests/fixtures/valid/return_var.c
+++ b/crates/cyan/tests/fixtures/valid/return_var.c
@@ -1,0 +1,4 @@
+int main(void) {
+  int a = 2;
+  return a;
+}

--- a/crates/cyan/tests/fixtures/valid/short_circuit_and_fail.c
+++ b/crates/cyan/tests/fixtures/valid/short_circuit_and_fail.c
@@ -1,0 +1,11 @@
+#ifdef SUPPRESS_WARNINGS
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wunused-value"
+#endif
+#endif
+
+int main(void) {
+  int a = 0;
+  0 && (a = 5);
+  return a;
+}

--- a/crates/cyan/tests/fixtures/valid/short_circuit_or.c
+++ b/crates/cyan/tests/fixtures/valid/short_circuit_or.c
@@ -1,0 +1,11 @@
+#ifdef SUPPRESS_WARNINGS
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wunused-value"
+#endif
+#endif
+
+int main(void) {
+  int a = 0;
+  1 || (a = 1);
+  return a;
+}

--- a/crates/cyan/tests/fixtures/valid/unused_exp.c
+++ b/crates/cyan/tests/fixtures/valid/unused_exp.c
@@ -1,0 +1,8 @@
+#ifdef SUPPRESS_WARNINGS
+#pragma GCC diagnostic ignored "-Wunused-value"
+#endif
+
+int main(void) {
+  2 + 2;
+  return 0;
+}

--- a/crates/cyan/tests/fixtures/valid/use_assignment_result.c
+++ b/crates/cyan/tests/fixtures/valid/use_assignment_result.c
@@ -1,0 +1,5 @@
+int main(void) {
+  int a = 1;
+  int b = 2;
+  return a = b = 4;
+}

--- a/crates/cyan/tests/fixtures/valid/use_in_initializer.c
+++ b/crates/cyan/tests/fixtures/valid/use_in_initializer.c
@@ -1,0 +1,4 @@
+int main(void) {
+  int a = a + 1;
+  return a;
+}

--- a/crates/cyan/tests/test_compiler.rs
+++ b/crates/cyan/tests/test_compiler.rs
@@ -6,82 +6,87 @@ use rayon::prelude::*;
 
 #[test]
 fn test_compiler() {
-  // (name, suite, should_succeed)
+  // (suite_path, should_succeed)
   let suites = vec![
-    ("valid", "tests/fixtures/valid", true),
-    ("invalid_lex", "tests/fixtures/invalid_lex", false),
-    ("invalid_parse", "tests/fixtures/invalid_parse", false),
+    ("tests/fixtures/valid", true),
+    ("tests/fixtures/invalid_lex", false),
+    ("tests/fixtures/invalid_parse", false),
+    ("tests/fixtures/invalid_semantics", false),
   ];
 
-  suites
-    .par_iter()
-    .for_each(|(suite_name, suite_path, should_succeed)| {
-      let suite_path = PathBuf::from(suite_path);
+  suites.par_iter().for_each(|(suite_path, should_succeed)| {
+    let suite_path = PathBuf::from(suite_path);
 
-      let inputs = suite_path
-        .read_dir()
-        .expect("suite directory should exist")
-        .filter_map(|entry| {
-          entry.ok().and_then(|entry| {
-            let path = entry.path();
+    let suite_name = suite_path
+      .file_name()
+      .expect("should have suite name")
+      .to_string_lossy()
+      .to_string();
 
-            if path.extension().and_then(|ext| ext.to_str()) == Some("c") {
-              Some(path)
-            } else {
-              None
-            }
-          })
+    let inputs = suite_path
+      .read_dir()
+      .expect("suite directory should exist")
+      .filter_map(|entry| {
+        entry.ok().and_then(|entry| {
+          let path = entry.path();
+
+          if path.extension().and_then(|ext| ext.to_str()) == Some("c") {
+            Some(path)
+          } else {
+            None
+          }
         })
-        .collect::<Vec<_>>();
+      })
+      .collect::<Vec<_>>();
 
-      inputs.par_iter().for_each(|input| {
-        let file = input
-          .file_name()
-          .expect("should have file name")
-          .to_string_lossy()
-          .to_string();
+    inputs.par_iter().for_each(|input| {
+      let file = input
+        .file_name()
+        .expect("should have file name")
+        .to_string_lossy()
+        .to_string();
 
-        let binary = input.with_extension("out");
+      let binary = input.with_extension("out");
 
-        // Buffer output for this file.
-        let mut message = String::new();
+      // Buffer output for this file.
+      let mut message = String::new();
 
-        message.push_str(&format!("{suite_name}/{file} ... "));
+      message.push_str(&format!("{suite_name}/{file} ... "));
 
-        let output = Command::new("cargo")
-          .args(["run", "--quiet", "--package", "cyan", "--"])
-          .args([&input.display().to_string()])
-          .args(["-o", &binary.display().to_string()])
-          .output()
-          .expect("should get output");
+      let output = Command::new("cargo")
+        .args(["run", "--quiet", "--package", "cyan", "--"])
+        .args([&input.display().to_string()])
+        .args(["-o", &binary.display().to_string()])
+        .output()
+        .expect("should get output");
 
-        let succeeded = output.status.success();
+      let succeeded = output.status.success();
 
-        if should_succeed == &succeeded {
-          message.push_str("PASS\n");
-        } else {
-          let actual_result = if succeeded { "OK" } else { "FAIL" };
-          let expected_result = if *should_succeed { "OK" } else { "FAIL" };
+      if should_succeed == &succeeded {
+        message.push_str("PASS\n");
+      } else {
+        let actual_result = if succeeded { "OK" } else { "FAIL" };
+        let expected_result = if *should_succeed { "OK" } else { "FAIL" };
 
-          message.push_str(&format!(
-            "{actual_result}, but expected {expected_result}\n"
-          ));
-        }
+        message.push_str(&format!(
+          "{actual_result}, but expected {expected_result}\n"
+        ));
+      }
 
-        // Print buffered output before assertion.
-        print!("{message}");
+      // Print buffered output before assertion.
+      print!("{message}");
 
-        // Remove generated binary.
-        if binary.is_file() {
-          fs::remove_file(&binary).expect("should remove binary");
-        }
+      // Remove generated binary.
+      if binary.is_file() {
+        fs::remove_file(&binary).expect("should remove binary");
+      }
 
-        // Perform assertions.
-        if *should_succeed {
-          assert!(succeeded);
-        } else {
-          assert!(!succeeded);
-        }
-      });
+      // Perform assertions.
+      if *should_succeed {
+        assert!(succeeded);
+      } else {
+        assert!(!succeeded);
+      }
     });
+  });
 }

--- a/crates/cyan_compiler/src/analysis/mod.rs
+++ b/crates/cyan_compiler/src/analysis/mod.rs
@@ -1,0 +1,3 @@
+pub use var_resolution::*;
+
+mod var_resolution;

--- a/crates/cyan_compiler/src/analysis/var_resolution.rs
+++ b/crates/cyan_compiler/src/analysis/var_resolution.rs
@@ -1,0 +1,205 @@
+use std::collections::hash_map::{Entry, HashMap};
+
+use cyan_reporting::{Located, Location};
+use internment::Intern;
+use thiserror::Error;
+
+use crate::context::Context;
+use crate::ir::ast::*;
+
+pub type Result<T> = std::result::Result<T, VarResolutionError>;
+
+/// A mapping from the user-defined variable names to the unique names to be used later.
+pub type VarMap = HashMap<Intern<String>, String>;
+
+#[derive(Debug, Error)]
+#[error("variable resolution error {location}: {message}")]
+pub struct VarResolutionError {
+  /// The error message.
+  message: String,
+  /// The location of the error.
+  location: Location,
+}
+
+impl VarResolutionError {
+  pub fn new(message: impl AsRef<str> + Into<String>, location: Location) -> Self {
+    Self {
+      message: message.into(),
+      location,
+    }
+  }
+}
+
+pub struct VarResolutionPass<'ctx> {
+  ctx: &'ctx mut Context,
+}
+
+impl<'ctx> VarResolutionPass<'ctx> {
+  pub fn new(ctx: &'ctx mut Context) -> Self {
+    Self { ctx }
+  }
+
+  pub fn run(&mut self, program: &Program) -> Result<Program> {
+    self.resolve_program(program)
+  }
+
+  fn resolve_program(&mut self, program: &Program) -> Result<Program> {
+    let function = self.resolve_function(&program.function)?;
+
+    Ok(Program {
+      function,
+      location: program.location,
+    })
+  }
+
+  fn resolve_function(&mut self, function: &Function) -> Result<Function> {
+    let mut variables: VarMap = HashMap::new();
+    let mut body = Vec::new();
+
+    // Set the prefix for temporary variables to current function's name.
+    self.ctx.var_prefix = function.name.value;
+
+    for block_item in &function.body {
+      body.push(self.resolve_block_item(block_item, &mut variables)?);
+    }
+
+    Ok(Function {
+      name: function.name,
+      body,
+      location: function.location,
+    })
+  }
+
+  fn resolve_block_item(
+    &mut self,
+    block_item: &BlockItem,
+    variables: &mut VarMap,
+  ) -> Result<BlockItem> {
+    match block_item {
+      | BlockItem::Declaration(declaration) => {
+        self
+          .resolve_declaration(declaration, variables)
+          .map(BlockItem::Declaration)
+      },
+      | BlockItem::Statement(statement) => {
+        self
+          .resolve_statement(statement, variables)
+          .map(BlockItem::Statement)
+      },
+    }
+  }
+
+  fn resolve_declaration(
+    &mut self,
+    declaration: &Declaration,
+    variables: &mut VarMap,
+  ) -> Result<Declaration> {
+    if let Entry::Vacant(entry) = variables.entry(declaration.name.value) {
+      // Generate unique name and associate a user-defined name with it.
+      let unique_name = self.ctx.gen_label(&declaration.name.value);
+      entry.insert(unique_name.to_string());
+
+      // Resolve initializer if there is one.
+      let resolved_init = declaration
+        .initializer
+        .as_ref()
+        .map(|init| self.resolve_expression(init, variables))
+        .transpose()?;
+
+      Ok(Declaration {
+        name: Ident {
+          value: unique_name,
+          location: declaration.name.location, // FIXME: This is probably incorrect.
+        },
+        initializer: resolved_init,
+        location: declaration.location,
+      })
+    } else {
+      Err(VarResolutionError::new(
+        "duplicate variable declaration",
+        declaration.name.location,
+      ))
+    }
+  }
+
+  fn resolve_statement(&self, statement: &Statement, variables: &mut VarMap) -> Result<Statement> {
+    match statement {
+      | Statement::Return(expression) => {
+        self
+          .resolve_expression(expression, variables)
+          .map(Statement::Return)
+      },
+      | Statement::Expression(expression) => {
+        self
+          .resolve_expression(expression, variables)
+          .map(Statement::Expression)
+      },
+      | Statement::Null { location } => {
+        Ok(Statement::Null {
+          location: *location,
+        })
+      },
+    }
+  }
+
+  #[allow(clippy::only_used_in_recursion)]
+  fn resolve_expression(
+    &self,
+    expression: &Expression,
+    variables: &mut VarMap,
+  ) -> Result<Expression> {
+    match expression {
+      | Expression::Constant(int) => Ok(Expression::Constant(*int)),
+      | Expression::Var(ident) => {
+        if let Some(name) = variables.get(&ident.value) {
+          Ok(Expression::Var(Ident {
+            value: name.clone().into(),
+            location: ident.location,
+          }))
+        } else {
+          Err(VarResolutionError::new(
+            format!("variable '{}' is undefined", ident.value),
+            ident.location,
+          ))
+        }
+      },
+      | Expression::Unary(unary) => {
+        let expression = self.resolve_expression(&unary.expression, variables)?;
+
+        Ok(Expression::Unary(Unary {
+          op: unary.op,
+          expression: Box::new(expression),
+          location: unary.location,
+        }))
+      },
+      | Expression::Binary(binary) => {
+        let left = self.resolve_expression(&binary.left, variables)?;
+        let right = self.resolve_expression(&binary.right, variables)?;
+
+        Ok(Expression::Binary(Binary {
+          op: binary.op,
+          left: Box::new(left),
+          right: Box::new(right),
+          location: binary.location,
+        }))
+      },
+      | Expression::Assignment(assignment) => {
+        if let Expression::Var(..) = &*assignment.left {
+          let left = self.resolve_expression(&assignment.left, variables)?;
+          let right = self.resolve_expression(&assignment.right, variables)?;
+
+          Ok(Expression::Assignment(Assignment {
+            left: Box::new(left),
+            right: Box::new(right),
+            location: assignment.location,
+          }))
+        } else {
+          Err(VarResolutionError::new(
+            "expression must be a modifiable lvalue",
+            *assignment.left.location(),
+          ))
+        }
+      },
+    }
+  }
+}

--- a/crates/cyan_compiler/src/analysis/var_resolution.rs
+++ b/crates/cyan_compiler/src/analysis/var_resolution.rs
@@ -10,7 +10,7 @@ use crate::ir::ast::*;
 pub type Result<T> = std::result::Result<T, VarResolutionError>;
 
 /// A mapping from the user-defined variable names to the unique names to be used later.
-pub type VarMap = HashMap<Intern<String>, String>;
+pub type VarMap = HashMap<Intern<String>, Intern<String>>;
 
 #[derive(Debug, Error)]
 #[error("variable resolution error {location}: {message}")]
@@ -97,7 +97,7 @@ impl<'ctx> VarResolutionPass<'ctx> {
     if let Entry::Vacant(entry) = variables.entry(declaration.name.value) {
       // Generate unique name and associate a user-defined name with it.
       let unique_name = self.ctx.gen_label(&declaration.name.value);
-      entry.insert(unique_name.to_string());
+      entry.insert(unique_name);
 
       // Resolve initializer if there is one.
       let resolved_init = declaration
@@ -153,7 +153,7 @@ impl<'ctx> VarResolutionPass<'ctx> {
       | Expression::Var(ident) => {
         if let Some(name) = variables.get(&ident.value) {
           Ok(Expression::Var(Ident {
-            value: name.clone().into(),
+            value: *name,
             location: ident.location,
           }))
         } else {

--- a/crates/cyan_compiler/src/context.rs
+++ b/crates/cyan_compiler/src/context.rs
@@ -1,0 +1,37 @@
+use internment::Intern;
+
+/// The compiler context.
+///
+/// This context is used to store global information about the compiler, such as the current
+/// function, the variable counter, etc.
+pub struct Context {
+  /// The current function.
+  pub var_prefix: Intern<String>,
+  /// The current variables/labels counter.
+  pub var_counter: usize,
+}
+
+impl Context {
+  pub fn new() -> Self {
+    Self {
+      var_prefix: "global".to_string().into(),
+      var_counter: 0,
+    }
+  }
+
+  /// Generates a label name using `label` as a prefix and increments the counter.
+  pub fn gen_label(&mut self, label: &str) -> Intern<String> {
+    let label = format!("{}.{}", self.var_prefix, label);
+    self.var_counter += 1;
+
+    label.into()
+  }
+
+  /// Generates a temporary variable name scoped to the current function and increments the counter.
+  pub fn gen_temporary(&mut self) -> Intern<String> {
+    let name = format!("{}.{}", self.var_prefix, self.var_counter);
+    self.var_counter += 1;
+
+    name.into()
+  }
+}

--- a/crates/cyan_compiler/src/ir/ast/mod.rs
+++ b/crates/cyan_compiler/src/ir/ast/mod.rs
@@ -112,13 +112,13 @@ pub struct Assignment {
   pub location: Location,
 }
 
-#[derive(Clone, Debug, Located, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Located, PartialEq, Eq)]
 pub struct Int {
   pub value: isize,
   pub location: Location,
 }
 
-#[derive(Clone, Debug, Located, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Located, PartialEq, Eq)]
 pub struct Ident {
   pub value: Intern<String>,
   pub location: Location,

--- a/crates/cyan_compiler/src/ir/ast/mod.rs
+++ b/crates/cyan_compiler/src/ir/ast/mod.rs
@@ -12,20 +12,37 @@ pub struct Program {
 #[derive(Debug, Located, PartialEq, Eq)]
 pub struct Function {
   pub name: Ident,
-  pub body: Statement,
+  pub body: Vec<BlockItem>,
+  pub location: Location,
+}
+
+#[derive(Debug, Located, PartialEq, Eq)]
+pub enum BlockItem {
+  Declaration(Declaration),
+  Statement(Statement),
+}
+
+#[derive(Debug, Located, PartialEq, Eq)]
+pub struct Declaration {
+  pub name: Ident,
+  pub initializer: Option<Expression>,
   pub location: Location,
 }
 
 #[derive(Debug, Located, PartialEq, Eq)]
 pub enum Statement {
   Return(Expression),
+  Expression(Expression),
+  Null { location: Location },
 }
 
 #[derive(Clone, Debug, Located, PartialEq, Eq)]
 pub enum Expression {
   Constant(Int),
+  Var(Ident),
   Unary(Unary),
   Binary(Binary),
+  Assignment(Assignment),
 }
 
 #[derive(Clone, Debug, Located, PartialEq, Eq)]
@@ -86,6 +103,13 @@ pub enum BinaryOp {
   LessEqual,
   NotEqual,
   Or,
+}
+
+#[derive(Clone, Debug, Located, PartialEq, Eq)]
+pub struct Assignment {
+  pub left: Box<Expression>,
+  pub right: Box<Expression>,
+  pub location: Location,
 }
 
 #[derive(Clone, Debug, Located, PartialEq, Eq)]

--- a/crates/cyan_compiler/src/ir/tac/passes.rs
+++ b/crates/cyan_compiler/src/ir/tac/passes.rs
@@ -60,12 +60,32 @@ impl LoweringPass {
 
     let mut instructions = Vec::new();
 
-    self.emit_statement(&function.body, &mut instructions)?;
+    for block_item in &function.body {
+      self.emit_block_item(block_item, &mut instructions)?;
+    }
 
     Ok(Function {
       name: function.name.value,
       instructions,
     })
+  }
+
+  /// Emits instructions for block item.
+  fn emit_block_item(
+    &mut self,
+    block_item: &ast::BlockItem,
+    instructions: &mut Vec<Instruction>,
+  ) -> Result<(), LoweringError> {
+    match block_item {
+      | ast::BlockItem::Declaration(declaration) => {
+        unimplemented!("declaration: {declaration:?}");
+      },
+      | ast::BlockItem::Statement(statement) => {
+        self.emit_statement(statement, instructions)?;
+      },
+    }
+
+    Ok(())
   }
 
   /// Emits instructions for statements.
@@ -81,6 +101,7 @@ impl LoweringPass {
 
         Ok(())
       },
+      | _ => unimplemented!("statement: {statement:?}"),
     }
   }
 
@@ -97,6 +118,7 @@ impl LoweringPass {
       | ast::Expression::Binary(binary) if binary.is_and() => self.emit_and(binary, instructions),
       | ast::Expression::Binary(binary) if binary.is_or() => self.emit_or(binary, instructions),
       | ast::Expression::Binary(binary) => self.emit_binary(binary, instructions),
+      | _ => unimplemented!("expression: {expression:?}"),
     }
   }
 

--- a/crates/cyan_compiler/src/lexer/lexer.rs
+++ b/crates/cyan_compiler/src/lexer/lexer.rs
@@ -48,6 +48,27 @@ impl<'i> Lexer<'i> {
     tokens
   }
 
+  /// Lexes the input and returns a vector of tokens, but all tokens have their `location` set to
+  /// `Location::default()`. Needed for testing.
+  #[cfg(test)]
+  pub fn lex_locationless(&mut self) -> Vec<Token> {
+    let location = Location::default();
+    let mut tokens = Vec::new();
+
+    loop {
+      let token = self.next().with_location(location);
+      let kind = token.kind;
+
+      tokens.push(token);
+
+      if kind == TokenKind::Eof {
+        break;
+      }
+    }
+
+    tokens
+  }
+
   /// Returns `true` if there is another byte to process.
   #[inline]
   fn has_next(&self) -> bool {

--- a/crates/cyan_compiler/src/lexer/token.rs
+++ b/crates/cyan_compiler/src/lexer/token.rs
@@ -130,6 +130,11 @@ impl Token {
     Self::new(TokenKind::Eof, String::new(), location)
   }
 
+  /// Returns the same token with the given location.
+  pub fn with_location(self, location: Location) -> Self {
+    Self { location, ..self }
+  }
+
   /// Returns `true` if the token is the end of input token.
   pub fn is_eof(&self) -> bool {
     self.kind == TokenKind::Eof
@@ -140,6 +145,14 @@ impl Token {
     matches!(
       self.kind,
       TokenKind::IntKw | TokenKind::VoidKw | TokenKind::ReturnKw
+    )
+  }
+
+  /// Returns `true` if the token is a unary operator.
+  pub fn is_unary_operator(&self) -> bool {
+    matches!(
+      self.kind,
+      TokenKind::BitNot | TokenKind::Sub | TokenKind::Bang
     )
   }
 
@@ -168,6 +181,8 @@ impl Token {
         | TokenKind::LessEqual
         | TokenKind::NotEqual
         | TokenKind::Or
+        // Assignment operator.
+        | TokenKind::Assign
     )
   }
 }

--- a/crates/cyan_compiler/src/lib.rs
+++ b/crates/cyan_compiler/src/lib.rs
@@ -4,6 +4,8 @@
   clippy::new_without_default
 )]
 
+pub mod analysis;
+pub mod context;
 pub mod emitter;
 pub mod ir;
 pub mod lexer;


### PR DESCRIPTION
## Description

This PR implements local variables declaration, assignments, and references. It also adds a simple semantic analysis pass to validate (and transform, if needed) AST before lowering to other IRs.

### AST & Parser

- [x] Update AST definition.
- [x] Update precedence levels to include assignment operator `=`.
- [x] Update parser to parse right-associative assignment operator and new syntax constructions like declarations, statement expressions, 'null' statements, etc.
- [x] Refactor parser tests to make them less verbose and easier to write/read.

### Semantic analysis

- [x] Sketch out and implement this pass to rewrite AST before lowering it into TAC.
\
  Right now it will, like all other steps, simply short-circuit compilation. Later on it would be nice to let parser recover from errors and emit all possible diagnostic messages.

### TAC

- [x] ~~Update TAC definition.~~ TAC remains the same.
- [x] Update lowering pass to handle assignments, declarations' initializers, etc.

### AAST

- [x] ~~Update AAST definition.~~
- [x] ~~Update lowering pass to handle new instructions.~~

AAST remains the same and no new instructions were added.

### Tests

- [x] Add compiler tests to cover new language features.